### PR TITLE
Make Apache installation optional via httpd role

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ phpmyadmin_database_allownopassword: false
 ## [Requirements](#requirements)
 
 - pip packages listed in [requirements.txt](https://github.com/robertdebock/ansible-role-phpmyadmin/blob/master/requirements.txt).
+- The `robertdebock.httpd` role must be installed manually. Set `phpmyadmin_enable_httpd: true` to enable the Apache installation.
 
 ## [State of used roles](#state-of-used-roles)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@
 # The version of PHPMyAdmin to install
 phpmyadmin_version: "5.2.1"
 
+# Enable the httpd service via the httpd role.
+phpmyadmin_enable_httpd: true
+
 # Where to connect to for the database.
 phpmyadmin_database_host: localhost
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart httpd
+  ansible.builtin.service:
+    name: httpd
+    state: restarted
+  when: phpmyadmin_enable_httpd | bool

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,5 +26,3 @@ galaxy_info:
     - installer
     - package
 
-dependencies:
-  - role: robertdebock.httpd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,11 @@
   run_once: true
   delegate_to: localhost
 
+- name: Install Apache httpd if enable
+  include_role:
+    name: robertdebock.httpd
+  when: phpmyadmin_enable_httpd | bool
+
 - name: Install requirements
   ansible.builtin.package:
     name: "{{ phpmyadmin_requirements }}"


### PR DESCRIPTION
**Describe the change**
This pull request introduces a new variable, `phpmyadmin_enable_httpd`, which allows users to enable or disable the installation and restart of Apache (`httpd`) when using the phpmyadmin role.
By default, `phpmyadmin_enable_httpd` is set to `true` to keep the previous behavior.
The inclusion of the `robertdebock.httpd` role and the related handler are now conditional, providing more flexibility for those who use a different web server or manage Apache externally.

---

**Testing**

* Tested with `phpmyadmin_enable_httpd: true` (default): Apache is installed and restarted as expected; phpmyadmin is accessible.
* Tested with `phpmyadmin_enable_httpd: false`: Apache is not installed or managed by the role; no unnecessary restarts are triggered.
* Playbooks executed in both scenarios, results confirmed via service state and application accessibility.

